### PR TITLE
fix: TypeError: 'str' object is not callable issue

### DIFF
--- a/lib/loader/loaderfactory.py
+++ b/lib/loader/loaderfactory.py
@@ -52,7 +52,7 @@ class TemplateLoaderFactory:  # pylint: disable=too-few-public-methods
         return None
 
     def _guess_by_extension(self, filepath):
-        _, ext = os.path.splitext(filepath)
+        i, ext = os.path.splitext(filepath)  # pylint: disable=unused-variable
         if ext in (".yaml", ".yml"):
             logging.debug(_("YAML extension %s"), ext)
             return TEMPLATE_YAML


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New enhancement (non-breaking change which adds small functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a build update
- [ ] This change requires a configuration update

## Developer Configuration

- OS:
- Python version:

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] Any dependent changes have been merged and published in downstream modules
